### PR TITLE
Update Pipfile.lock with new python version

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -5,14 +5,14 @@
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
-            "implementation_version": "3.6.3",
+            "implementation_version": "3.6.4",
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
             "platform_release": "4.10.0-42-generic",
             "platform_system": "Linux",
             "platform_version": "#46~16.04.1-Ubuntu SMP Mon Dec 4 15:57:59 UTC 2017",
-            "python_full_version": "3.6.3",
+            "python_full_version": "3.6.4",
             "python_version": "3.6",
             "sys_platform": "linux"
         },


### PR DESCRIPTION
#29 didn't quite work because the Python version needs to be updated in `Pipenv.lock`. I'm learning!