### PR TITLE
Disable smoke tests in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,12 @@ unit-test:
 	coverage report
 
 functional-test:
-	python manage.py behave
+	python manage.py behave -e smoke.feature
 
 test: lint unit-test functional-test
 
 smoke:
-	REMOTE_URL=$(REMOTE_URL) python manage.py behave features/smoke.feature 
+	REMOTE_URL=$(REMOTE_URL) python manage.py behave -i smoke.feature
 
 docs:
 	cd docs/; make html

--- a/Pipfile
+++ b/Pipfile
@@ -29,4 +29,4 @@ behave-django = "*"
 
 [requires]
 
-python_full_version = "3.6.4"
+python_version = "3.6"

--- a/features/environment.py
+++ b/features/environment.py
@@ -21,9 +21,10 @@ def before_all(context):
             browser = context.browser = Browser('chrome', options=options)
 
         return browser
-
-    context.remote_url = os.environ.get('REMOTE_URL', 'http://localhost:5000')
     context.get_browser = get_browser
+
+    # Remote URL for smoke testing
+    context.remote_url = os.environ.get('REMOTE_URL', 'http://localhost:5000')
 
 
 def _debug():

--- a/features/steps/smoke.py
+++ b/features/steps/smoke.py
@@ -8,4 +8,4 @@ def step_impl(context):
 
 @then(u'the page should load')
 def step_impl(context):
-    assert context.get_browser().status_code.is_success()
+    assert 'Nibble' in context.get_browser().title


### PR DESCRIPTION
This disables smoke tests in CI because there's no remote URL. Fixes #35 